### PR TITLE
feat(blog): Xcode 27 agentic workflows

### DIFF
--- a/_posts/2026-06-11-xcode-27-agentic-workflows.md
+++ b/_posts/2026-06-11-xcode-27-agentic-workflows.md
@@ -1,0 +1,103 @@
+---
+layout: post
+title: "What Xcode 27 Means for Agentic iOS Workflows"
+date: 2026-06-11 00:00:00 +0000
+description: "Apple’s Xcode 27 update reframes coding agents from novelty to daily workflow surface. Here’s what changed and how I’m adapting my process."
+tags: [ai, ios, xcode, developer-tools, workflow]
+---
+
+I pay attention to tooling updates for one reason: they change what is realistic in a single work session.
+
+Xcode 27 is one of those updates.
+
+Apple’s latest Xcode page now positions agentic coding as a first-class development workflow, not just an assistive feature. That sounds like marketing until you map it against day-to-day work: planning, editing, debugging, and iteration inside a single IDE flow.
+
+## The practical shift
+
+Before this cycle, my default pattern was:
+
+1. Spec in one window
+2. Code in another
+3. Use AI tools in parallel
+4. Reconcile output manually
+
+Xcode 27 pushes this toward a tighter loop:
+
+1. Define intent
+2. Run agent-assisted code generation/debugging in context
+3. Validate quickly
+4. Iterate with fewer context jumps
+
+That sounds small, but reducing context switches is a major productivity gain for solo operators.
+
+## Why this is bigger than autocomplete
+
+Autocomplete helps at line level. Agentic workflows help at task level.
+
+The difference is scope:
+
+- **Autocomplete:** “finish this statement”
+- **Agentic assist:** “implement this flow, then debug why it fails”
+
+If the tooling can hold enough context to reason across files and follow symbol usage correctly, it becomes useful for real issue-sized work, not just snippets.
+
+## What I’m changing in my process
+
+I’m adopting a stricter execution pattern that assumes the assistant can do more, but still requires explicit gates:
+
+1. **Issue-first prompts**
+   - Give the agent acceptance criteria, not vague goals.
+2. **Evidence-before-claim**
+   - Require file/path evidence for implementation claims.
+3. **Short loops**
+   - Keep each run constrained to one shippable slice.
+4. **Human QA remains final**
+   - Especially for user-facing behavior and iOS nuance.
+
+This keeps the productivity upside without drifting into “looks done” false positives.
+
+## Where it helps most
+
+The strongest use cases for me:
+
+- Refactors with clear boundaries
+- Test scaffolding and edge-case expansion
+- Repetitive project wiring
+- Fast bug triage where logs and call paths are clear
+
+The weakest:
+
+- Ambiguous product decisions
+- Brand or UX judgment calls
+- Anything that needs domain nuance beyond code mechanics
+
+In other words: delegate mechanics, keep judgment.
+
+## A simple setup I’m using
+
+I’m treating agentic support like an engineering subsystem:
+
+```text
+Prompt quality -> deterministic output quality
+Validation discipline -> deployment confidence
+Context hygiene -> sustained session quality
+```
+
+That mindset prevents the two common mistakes:
+
+1. Over-trusting generated output
+2. Under-specifying the task and blaming the tool
+
+## Closing thought
+
+The most useful framing for Xcode 27 is not “AI can code now.”
+
+It’s this: **the IDE is becoming an orchestration surface**.
+
+For builders, that means the winning skill isn’t just writing code. It’s designing reliable loops between intent, execution, and verification.
+
+If you’re testing this update, start with one bounded workflow and measure cycle time + rework. That tells you quickly whether the new surface is actually helping.
+
+### Sources
+
+- [Xcode — Apple Developer](https://developer.apple.com/xcode/)

--- a/_posts/2026-06-11-xcode-27-agentic-workflows.md
+++ b/_posts/2026-06-11-xcode-27-agentic-workflows.md
@@ -10,7 +10,7 @@ I pay attention to tooling updates for one reason: they change what is realistic
 
 Xcode 27 is one of those updates.
 
-Apple’s latest Xcode page now positions agentic coding as a first-class development workflow, not just an assistive feature. That sounds like marketing until you map it against day-to-day work: planning, editing, debugging, and iteration inside a single IDE flow.
+Apple’s latest Xcode page explicitly highlights “predictive code completion” and “generative intelligence powered by the best coding models and agents.” My read is that this signals a stronger workflow emphasis than older “autocomplete-only” framing — but that interpretation is mine, not an Apple guarantee of end-to-end automation.
 
 ## The practical shift
 
@@ -28,18 +28,18 @@ Xcode 27 pushes this toward a tighter loop:
 3. Validate quickly
 4. Iterate with fewer context jumps
 
-That sounds small, but reducing context switches is a major productivity gain for solo operators.
+In my own workflow, fewer context switches usually improve cycle time. Treat this as personal inference, not a universal outcome.
 
 ## Why this is bigger than autocomplete
 
-Autocomplete helps at line level. Agentic workflows help at task level.
+Autocomplete helps at line level. Agentic workflows can help at task level when prompts and constraints are clear.
 
 The difference is scope:
 
 - **Autocomplete:** “finish this statement”
 - **Agentic assist:** “implement this flow, then debug why it fails”
 
-If the tooling can hold enough context to reason across files and follow symbol usage correctly, it becomes useful for real issue-sized work, not just snippets.
+If the tooling can hold enough context to reason across files and follow symbol usage correctly, it becomes useful for issue-sized work in my testing — but reliability still varies by task complexity.
 
 ## What I’m changing in my process
 
@@ -90,14 +90,17 @@ That mindset prevents the two common mistakes:
 
 ## Closing thought
 
-The most useful framing for Xcode 27 is not “AI can code now.”
+The most useful framing for Xcode 27, for me, is not “AI can code now.”
 
-It’s this: **the IDE is becoming an orchestration surface**.
+It’s this: **the IDE is becoming more of an orchestration surface**.
 
-For builders, that means the winning skill isn’t just writing code. It’s designing reliable loops between intent, execution, and verification.
+For builders, that suggests the winning skill isn’t just writing code. It’s designing reliable loops between intent, execution, and verification.
 
 If you’re testing this update, start with one bounded workflow and measure cycle time + rework. That tells you quickly whether the new surface is actually helping.
 
 ### Sources
 
 - [Xcode — Apple Developer](https://developer.apple.com/xcode/)
+  - Relevant Apple text (accessed 2026-06-11):
+    - “Xcode offers the tools you need to develop, test, and distribute apps for Apple platforms, including predictive code completion, generative intelligence powered by the best coding models and agents…”
+    - “Xcode also supports interacting with code using the large language model of your choice… including the advanced coding model and agents of Anthropic and OpenAI.”


### PR DESCRIPTION
## Summary
Add a new personal developer post on Xcode 27 agentic workflow implications.

## Changes
- New: _posts/2026-06-11-xcode-27-agentic-workflows.md

Refs foculoom/foculoom-project#1757